### PR TITLE
fix python version requirement config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "torchmetrics @ git+https://github.com/Lightning-AI/torchmetrics",
 ]
 readme = "README.md"
-requires-python = "== 3.11"
+requires-python = "== 3.11.*"
 
 [project.scripts]
 download_s2_4band_planet_format = "thaw_slump_segmentation.scripts.download_s2_4band_planet_format:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 dependencies = [
     "torch==2.2.0",
     "torchvision",
-    "numpy>=1.26.3",
+    "numpy>=1.26.3, <2",
     "efficientnet-pytorch==0.7.1",
     "wandb>=0.16.6",
     "pretrainedmodels>=0.7.4",


### PR DESCRIPTION
python "== 3.11" requirement makes `rye sync` fail with
```
Editable `thaw-slump-segmentation` requires Python ==3.11, but resolution targets Python 3.11.9
```
