### PR TITLE
Remove sub-dir models from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ dist/
 requirements.lock
 requirements-dev.lock
 wandb
-models
+/models


### PR DESCRIPTION
This will let python include the models directory again

Fixes #162 