### PR TITLE
Preprocessing/Inference improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ prepare_data = "thaw_slump_segmentation.scripts.prepare_data:main"
 setup_raw_data = "thaw_slump_segmentation.scripts.setup_raw_data:setup_raw_data"
 train = "thaw_slump_segmentation.scripts.train:main"
 thaw-slump-segmentation = "thaw_slump_segmentation.main:cli"
+build_dem_vrt = "thaw_slump_segmentation.data_pre_processing.dem:buildDemVrtMain"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/thaw_slump_segmentation/data_pre_processing/dem.py
+++ b/src/thaw_slump_segmentation/data_pre_processing/dem.py
@@ -1,0 +1,84 @@
+# The original Script
+# 
+# ARCTIC_DEM=path/to/base/folder
+# ls $ARCTIC_DEM/tiles_rel_el/*.tif > flist_rel_el.txt;
+# ls $ARCTIC_DEM/tiles_slope/*.tif > flist_slope.txt;
+# gdalbuildvrt -input_file_list flist_rel_el.txt -srcnodata "0" -vrtnodata "0" elevation.vrt;
+# gdalbuildvrt -input_file_list flist_slope.txt -srcnodata "nan" -vrtnodata "0" slope.vrt;
+#
+#
+# The Notebook to download ArtcicDEM data is here: https://github.com/initze/thaw_slump_preprocessing/blob/main/DEM_01_ProcessArcticDEM.ipynb
+
+import os
+from typing_extensions import Annotated
+from pathlib import Path
+import logging
+import typer
+
+subdirs = {
+    "elevation" : "tiles_rel_el",
+    "slope" : "tiles_slope"
+}
+
+l = logging.getLogger("thaw_slump_segmentation.preprocess.dem")
+
+buildDemVrtMain = typer.Typer()
+
+@buildDemVrtMain.command()
+def buildDemVrt(
+    dem_data_dir:Annotated[ Path, typer.Option("--dem_data_dir") ], 
+    vrt_target_dir:Annotated[ Path, typer.Option("--vrt_target_dir") ] 
+    ):
+    """parses the subfolders 'tiles_rel_el' and 'tiles_slope' of `dem_data_dir` to
+    create VRT (virtual raster tile) files (https://gdal.org/drivers/raster/vrt.html).
+
+    A working installation of the python gdal bindings is required!
+
+    Args:
+        dem_data_dir (Path): The folder containing the source folders
+        vrt_target_dir (Path): The folder where to write the VRT files
+
+    Raises:
+        EnvironmentError: if gdal python bindings could not be imported
+        IOError: If target files are not writable
+    """
+    
+    try:
+        from osgeo import gdal
+    except ModuleNotFoundError:
+        raise EnvironmentError("The python GDAL bindings where not found. Please install those which are appropriate for your platform.")
+
+    l.info(f"GDAL found: {gdal.__version__}")
+
+    # decide on the exception behavior of GDAL to supress a warning if we dont
+    # don't know if this is necessary in all GDAL versions
+    try:
+        gdal.UseExceptions()
+    except AttributeError():
+        pass
+    
+    # check first if BOTH files are writable
+    non_writable_files = []
+    for name in subdirs.keys():
+        output_file_path = vrt_target_dir / f"{name}.vrt"
+        if not (
+            (os.access(output_file_path, os.F_OK) and os.access(output_file_path, os.W_OK)) # f exists + writable
+            or os.access(output_file_path.parent, os.W_OK) # ...OR folder writable
+        ):
+            non_writable_files.append(output_file_path)
+    if len(non_writable_files) > 0:
+        raise IOError(f"cannot write to {', '.join([ f.name for f in non_writable_files ])}")
+
+    for name,subdir in subdirs.items():
+        output_file_path = vrt_target_dir / f"{name}.vrt"
+        # check the file first if we can write to it
+
+        ds_path = dem_data_dir / subdir
+        filelist = [ str(f.absolute().resolve()) for f in ds_path.glob("*.tif") ]
+        print(f"{len(filelist)} files for {name}")
+        print(f" --> '{output_file_path}'")
+        src_nodata = "nan" if name=="slope" else 0
+        gdal.BuildVRT( str(output_file_path.absolute()), filelist, options=gdal.BuildVRTOptions(srcNodata=src_nodata, VRTNodata=0) )
+
+if __name__ == "__main__":
+    buildDemVrtMain()

--- a/src/thaw_slump_segmentation/data_pre_processing/dem.py
+++ b/src/thaw_slump_segmentation/data_pre_processing/dem.py
@@ -75,8 +75,7 @@ def buildDemVrt(
 
         ds_path = dem_data_dir / subdir
         filelist = [ str(f.absolute().resolve()) for f in ds_path.glob("*.tif") ]
-        print(f"{len(filelist)} files for {name}")
-        print(f" --> '{output_file_path}'")
+        l.info(f"{len(filelist)} files for {name}\n --> '{output_file_path}'")
         src_nodata = "nan" if name=="slope" else 0
         gdal.BuildVRT( str(output_file_path.absolute()), filelist, options=gdal.BuildVRTOptions(srcNodata=src_nodata, VRTNodata=0) )
 

--- a/src/thaw_slump_segmentation/postprocessing.py
+++ b/src/thaw_slump_segmentation/postprocessing.py
@@ -34,6 +34,8 @@ def run_inference(
     gpu=0,
     patch_size=1024,
     margin_size=256,
+    gdal_bin = "/usr/bin",
+    gdal_path = "/usr/bin",
     **kwargs # consume legacy args (run)
 ):
     if len(df) == 0:
@@ -52,7 +54,8 @@ def run_inference(
             data_dir=processing_dir, inference_dir=inference_dir, 
             patch_size=patch_size, margin_size=margin_size, 
             model_path=model_dir/model, 
-            tile_to_predict=df.name.values
+            tile_to_predict=df.name.values,
+            gdal_bin=gdal_bin, gdal_path=gdal_path
             )
 
 

--- a/src/thaw_slump_segmentation/scripts/setup_raw_data.py
+++ b/src/thaw_slump_segmentation/scripts/setup_raw_data.py
@@ -43,6 +43,46 @@ SUCCESS_STATES = ['rename', 'label', 'ndvi', 'tcvis', 'rel_dem', 'slope', 'mask'
 
 
 def preprocess_directory(image_dir, data_dir, aux_dir, backup_dir, log_path, gdal_bin, gdal_path, label_required=True):
+    """Preprocess a folder of a source imagery dataset to use in the inference processing.
+    Notably this method generates additional data files to be used as auxiliary input of the inference
+    model: DEM derived data (relative elevation and slope), NDVI and the landsat trend data (tcvis).
+
+    In particular, the extend of the imagery in image_dir is used to generate a regional excerpt of the
+    other data from the aux_dir as well as Google Earth Engine and the input data itself. The regional
+    excerpts are stored as GeoTIFF alongside the source data in the data_dir folder.
+
+    Additionally, some data is copied to `backup_dir`.
+
+    GDAL is heavily used in the preprocessing, so the paths to a working gdal environment are required, 
+    usually the platform binaries or installed via conda.
+
+    To accesss data in Google Earth Engine this method will authenticate with the Google Earth Engine API,
+    so an active account at GEE is required.
+
+    The method returns a dictionary describing the success states of each processing stage. The keys are:
+    * rename
+    * label
+    * ndvi
+    * tcvis
+    * rel_dem
+    * slope
+    * mask
+    * move
+
+    Args:
+        image_dir (Path): The source folder
+        data_dir (Path): The folder where to store the preprocessed dataset
+        aux_dir (Path): source of auxiliary data, for now the DEM VRT files
+        backup_dir (Path): path to a folder where to store backups of the input data
+        log_path (Path): path where to write logging
+        gdal_bin (Path): Path to a folder with the gdal_binaries (gdalwarp etc.)
+        gdal_path (_type_): Path to a folder with gdal_scripts (gdal_retile.py etc)
+        label_required (bool, optional): If label data should be baked into the source data. Defaults to True.
+
+    Returns:
+        dict: a dictionary with the results of the individual processing stages
+    """
+    
     # Mock old args object
     gdal.initialize(bin=gdal_bin, path=gdal_path)
 

--- a/src/thaw_slump_segmentation/scripts/setup_raw_data.py
+++ b/src/thaw_slump_segmentation/scripts/setup_raw_data.py
@@ -127,8 +127,9 @@ def setup_raw_data(
     logger.info('# Starting Raw Data Setup #')
     logger.info('###########################')
 
+    logger.info(f"images to preprocess in {INPUT_DATA_DIR}")
     dir_list = check_input_data(INPUT_DATA_DIR)
-    print(dir_list)
+    [logger.info(f" * '{f.relative_to(INPUT_DATA_DIR)}'") for f in dir_list ]
     if len(dir_list) > 0:
         if n_jobs == 0:
             for image_dir in dir_list:

--- a/src/thaw_slump_segmentation/scripts/setup_raw_data.py
+++ b/src/thaw_slump_segmentation/scripts/setup_raw_data.py
@@ -132,8 +132,9 @@ def preprocess_directory(image_dir, data_dir, aux_dir, backup_dir, log_path, gda
     success_state['mask'] = mask_input_data(image_dir, data_dir)
 
     # backup_dir_full = os.path.join(backup_dir, os.path.basename(image_dir))
-    backup_dir_full = backup_dir / image_dir.name
-    success_state['move'] = move_files(image_dir, backup_dir_full)
+    if backup_dir is not None:
+        backup_dir_full = backup_dir / image_dir.name
+        success_state['move'] = move_files(image_dir, backup_dir_full)
 
     for status in SUCCESS_STATES:
         thread_logger.info(status + ': ' + STATUS[success_state[status]])

--- a/tests/test_DEM.py
+++ b/tests/test_DEM.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import pytest
+import tempfile
+import shutil
+
+from thaw_slump_segmentation.data_pre_processing.dem import buildDemVrt
+
+# check if we have the standard test data available
+
+
+def testWithData(data_dir:Path):
+    arcticdem_base_dir = data_dir / "auxiliary/ArcticDEM"
+
+    if not arcticdem_base_dir.exists():
+        pytest.skip(f"{arcticdem_base_dir} does not exist")
+
+    output_dir = tempfile.mkdtemp()
+    output_path = Path(output_dir)
+
+    buildDemVrt( arcticdem_base_dir, output_path)
+
+    assert (output_path / "elevation.vrt" ).exists()
+    assert (output_path / "slope.vrt" ).exists()
+
+    with (output_path / "elevation.vrt").open("r") as f:
+        assert f.read(11) == "<VRTDataset"
+    with (output_path / "slope.vrt").open("r") as f:
+        assert f.read(11) == "<VRTDataset"
+
+    shutil.rmtree(output_dir)
+


### PR DESCRIPTION
This PR adds some improvements to the main inference pipeline, notably to the `setup_raw_data`/`preprocess_directory` as well as the `run_inference`/`inference` chain of commands.

A major change is that we can now take advantage of the integration of typer and call some subprocesses natively instead of relying on os.system() calls and serialization of parameters. 

The changes to the arguments of run_inference() are either because they are unused (run) or just passed through to inference() with the same defaults (gdal_*).

Also added to this repository is the code to create the VRT files referencing the DEM data which uses gdal through the python GDAL binding (`gdal.BuildVRT`) instead of calling GDAL through CLI. The associated method can be called via command line as well as a function. Its currently only used in thaw-slump-segmentetion-pipeline but I felt it makes more sense in this repository.

Minor changes are a few fixes to the logging output, some documentation (#127) and writing into a backup directory is now optional during preprocessing.

This PR is required to incorporate the refactor work in thaw-slump-segmentation-pipeline on the process_02_inference.py script (Branch https://github.com/awi-response/thaw-slump-segmentation-pipeline/tree/process02basic) and to complete https://github.com/awi-response/thaw-slump-segmentation-pipeline/issues/6.